### PR TITLE
fix(ompl): set eps parameter

### DIFF
--- a/python/plainmp/ompl_solver.py
+++ b/python/plainmp/ompl_solver.py
@@ -183,6 +183,7 @@ class OMPLSolver:
                 vconfig,
             )
             planner.set_heuristic(guess.numpy())
+            planner.set_parameters(None, None, self.config.ertconnect_eps)
         else:
             planner = OMPLPlanner(
                 problem.lb,

--- a/python/plainmp/ompl_solver.py
+++ b/python/plainmp/ompl_solver.py
@@ -44,7 +44,11 @@ class OMPLSolverConfig:
     refine_seq: Sequence[RefineType] = tuple()
     shortcut: bool = False
     bspline: bool = False
-    ertconnect_eps: float = 5.0  # used only when ertconnect is selected
+    # these three parameters are used only when ERTConnect is selected
+    # NOTE: the default values are the same as the default values in the paper
+    ertconnect_omega_min: float = 0.05
+    ertconnect_omega_max: float = 0.1
+    ertconnect_eps: float = 5.0
     timeout: Optional[float] = None
     use_goal_sampler: bool = (
         False  # use goal sampler in unidirectional planner. Use only when the goal is not a point
@@ -183,7 +187,11 @@ class OMPLSolver:
                 vconfig,
             )
             planner.set_heuristic(guess.numpy())
-            planner.set_parameters(None, None, self.config.ertconnect_eps)
+            planner.set_parameters(
+                self.config.ertconnect_omega_min,
+                self.config.ertconnect_omega_max,
+                self.config.ertconnect_eps,
+            )
         else:
             planner = OMPLPlanner(
                 problem.lb,


### PR DESCRIPTION
compare hash value of the following script and checked that the hash value matches if eps=5.0, and does not match if 0.1.

original
```
h-ishida@umejuice:~/cpp/plainmp/example$ python3 tmp.py 
original: ecfdc4770e62b4daef34eae351eb8371
default eps=5.0: b6db7b56fe31dcd3a5e01509ba4e12c4
h-ishida@umejuice:~/cpp/plainmp/example$ python3 tmp.py --tweak
original: ecfdc4770e62b4daef34eae351eb8371
default eps=0.1: b6db7b56fe31dcd3a5e01509ba4e12c4
```

after this PR:
```
h-ishida@umejuice:~/cpp/plainmp/example$ python3 tmp.py 
original: ecfdc4770e62b4daef34eae351eb8371
default eps=5.0: b6db7b56fe31dcd3a5e01509ba4e12c4
h-ishida@umejuice:~/cpp/plainmp/example$ python3 tmp.py --tweak
original: ecfdc4770e62b4daef34eae351eb8371
default eps=0.1: d8359bf048089cf5e067504a470701d3
```

```python
import argparse
from hashlib import md5

import numpy as np

from plainmp.ompl_solver import OMPLSolver, set_log_level_none, set_random_seed
from plainmp.problem import Problem
from plainmp.robot_spec import FetchSpec

if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("--tweak", action="store_true", help="warm start")
    args = parser.parse_args()

    set_random_seed(1)
    set_log_level_none()
    fs = FetchSpec()
    cst = fs.create_collision_const()
    lb, ub = fs.angle_bounds()
    q_start = np.array([0.0, 1.32, 1.40, -0.20, 1.72, 0.0, 1.66, 0.0])
    q_goal = np.array([0.386, 0.205, 1.41, 0.308, -1.82, 0.245, 0.417, 6.01])
    resolution = np.ones(8) * 0.05
    problem = Problem(q_start, lb, ub, q_goal, cst, None, resolution)
    solver = OMPLSolver()
    ret = solver.solve(problem)
    md5_hash = md5(ret.traj.numpy().tobytes()).hexdigest()
    print(f"original: {md5_hash}")

    q_goal = np.array([0.1, 0.205, 1.41, 0.33, -1.4, 0.4, 0.2, 3.01])
    problem = Problem(q_start, lb, ub, q_goal, cst, None, resolution)

    if args.tweak:
        solver.config.ertconnect_eps = 0.1
    ret1 = solver.solve(problem, guess=ret.traj)
    md5_hash = md5(ret1.traj.numpy().tobytes()).hexdigest()
    print(f"default eps={solver.config.ertconnect_eps}: {md5_hash}")
```